### PR TITLE
on account confirm - don't clear confirmation_sent_at

### DIFF
--- a/lib/passport/modules/confirmable.ex
+++ b/lib/passport/modules/confirmable.ex
@@ -49,7 +49,6 @@ defmodule Passport.Confirmable do
     confirmed_at =  params[:confirmed_at] || Passport.Util.generate_timestamp_for(changeset, :confirmed_at)
     changeset
     |> put_change(:confirmation_token, nil)
-    |> put_change(:confirmation_sent_at, nil)
     |> put_change(:confirmed_at, confirmed_at)
   end
 


### PR DESCRIPTION
This change keeps the `confirmation_sent_at` timestamp after the user confirms their account.