### PR TITLE
expose # of failed login attempts if account locked

### DIFF
--- a/lib/passport/controllers/session_controller.ex
+++ b/lib/passport/controllers/session_controller.ex
@@ -101,6 +101,7 @@ defmodule Passport.SessionController do
 
       {:error, {:locked, entity}} ->
         conn
+        |> put_resp_header("x-failed-attempts", Integer.to_string(entity.failed_attempts))
         |> put_resp_header("x-locked-at", DateTime.to_string(entity.locked_at))
         |> send_locked(reason: "Too many failed attempts.")
 


### PR DESCRIPTION
This PR exposes the number of login attempts if the user tries to login and their account is locked.
It does so via the "x-login-attempts" header in the response.

The reason for this is to be able to differentiate the situations where the account could be:
- locked by admin (failed attempts == 0), and
- locked by too many failed login attempts (failed attempts > 0)

It's a hacky solution, the current lib doesn't document how to use the account `enabled` and `activated` flags for this use-case and I couldn't figure it out in a reasonable timeframe.